### PR TITLE
Missing #default_value property in the 'target_platform' form element.

### DIFF
--- a/hosting_quickmigrate.module
+++ b/hosting_quickmigrate.module
@@ -75,7 +75,8 @@ function hosting_task_quickmigrate_form($node) {
         '#type' => 'radio',
         '#title' => $platform->title,
         '#parents' => array('parameters', 'target_platform'),
-        "#return_value" => $platform->nid,
+        '#default_value' => $platform->nid,
+        '#return_value' => $platform->nid,
         '#description' => $description,
       );
       if ($status['error']) {


### PR DESCRIPTION
Hello,

The element https://github.com/nodeone/hosting-quickmigrate/blob/master/hosting_quickmigrate.module#L74 is missing a #default_value property.
This cause the target_platform value not returned in https://github.com/nodeone/hosting-quickmigrate/blob/master/hosting_quickmigrate.drush.inc#L13.
